### PR TITLE
Fix adb typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The command should land you inside the container shell. You will find every tool
 
 You can chose to mount USB device file as a bind mount for linux, But for mac and windows, you have to use remote ADB. To use host USB with ADB, **modify the command** like this (Should work on linux hosts) 
 
-    docker run --rm -it -v `pwd`:/app -v --privileged -v /dev/bus/usb:/dev/bus/usb --network host theanam/react-native bash
+    docker run --rm -it -v `pwd`:/app --privileged -v /dev/bus/usb:/dev/bus/usb --network host theanam/react-native bash
 
 For mac (and probably for windows, because I haven't tested), You need to follow some steps. 
 


### PR DESCRIPTION
Hello!

Just wanted to say thanks, this docker image saved me a ton of time and it works great!

One small thing, instead of passing the flag `--privileged`, there is a typo and it's considered a volume. It works if you remove the extra `-v`, otherwise your device won't be seen inside the container

Also, in my command I have added 
```
-v `pwd`/.gradle:/root/.gradle
```
this way you don't have to install gradle every time, you can add this as well if you want to

All the best